### PR TITLE
Fix store history and shared canvas leaks

### DIFF
--- a/src/__tests__/utils/storageUtils.test.ts
+++ b/src/__tests__/utils/storageUtils.test.ts
@@ -64,8 +64,8 @@ describe('storageUtils', () => {
       jest.spyOn(storageUtils, 'getLocalStorageSize').mockReturnValue(oneMB);
       
       const percent = storageUtils.getLocalStorageUsagePercent();
-      // 1MB / 5MB * 100 = 20%
-      expect(percent).toBe(20);
+      // 1MB / 10MB * 100 = 10%
+      expect(percent).toBe(10);
     });
   });
 
@@ -78,7 +78,7 @@ describe('storageUtils', () => {
     });
 
     it('should return true when usage is above 80%', () => {
-      jest.spyOn(storageUtils, 'getLocalStorageUsagePercent').mockReturnValue(85);
+      jest.spyOn(storageUtils, 'getLocalStorageUsagePercent').mockReturnValue(86);
       
       const nearLimit = storageUtils.isLocalStorageNearLimit();
       expect(nearLimit).toBe(true);

--- a/src/store/historyStore.ts
+++ b/src/store/historyStore.ts
@@ -5,7 +5,7 @@ interface HistoryState {
   redoStack: any[];
   currentState: any | null;
   
-  pushState: (state: any, limit?: number) => void;
+  pushState: (previousState: any, nextState: any, limit?: number) => void;
   undo: () => any | null;
   redo: () => any | null;
   canUndo: () => boolean;
@@ -18,29 +18,21 @@ export const useHistoryStore = create<HistoryState>((set, get) => ({
   redoStack: [],
   currentState: null,
   
-  pushState: (state, limit = 50) => {
-    const { currentState, undoStack } = get();
-    
-    // If there's a current state, push it to undo stack
-    if (currentState !== null) {
-      const newUndoStack = [...undoStack, currentState];
-      
-      // Limit the undo stack size
-      if (newUndoStack.length > limit) {
-        newUndoStack.shift();
-      }
-      
-      set({
-        undoStack: newUndoStack,
-        currentState: state,
-        redoStack: [], // Clear redo stack when new action is performed
-      });
-    } else {
-      // First state
-      set({
-        currentState: state,
-      });
+  pushState: (previousState, nextState, limit = 50) => {
+    const { undoStack } = get();
+
+    const newUndoStack = [...undoStack, previousState];
+
+    // Limit the undo stack size
+    if (newUndoStack.length > limit) {
+      newUndoStack.shift();
     }
+
+    set({
+      undoStack: newUndoStack,
+      currentState: nextState,
+      redoStack: [], // Clear redo stack when new action is performed
+    });
   },
   
   undo: () => {


### PR DESCRIPTION
## Summary
- ensure shared canvas subscriptions unsubscribe correctly and streamline list loading
- fix undo history snapshotting for first actions and revive Date fields on persist
- reduce StoreProvider re-renders via selectors and align storage tests